### PR TITLE
Share hosts file across containers

### DIFF
--- a/docs/shared_hosts_example.md
+++ b/docs/shared_hosts_example.md
@@ -1,0 +1,43 @@
+# Shared Hosts File Optimization for Containerlab
+
+## Overview
+
+This optimization implements industry-standard shared configuration file mounting for containerlab containers. Instead of generating individual `/etc/hosts` files for each container, we generate one shared hosts file per device type and mount it read-only into all containers of that type.
+
+## Benefits
+
+1. **Performance**: Eliminates redundant file generation (from N files to M device types)
+2. **Consistency**: All containers of the same type share identical host mappings
+3. **Security**: Read-only mounts prevent containers from modifying host entries
+4. **Simplicity**: Follows Docker best practices for shared configuration
+
+## Configuration
+
+Enable shared hosts files (default: true):
+```yaml
+defaults:
+  providers:
+    clab:
+      shared_hosts: true
+```
+
+## How It Works
+
+1. **Device Grouping**: Nodes are grouped by device type (e.g., all 'linux' nodes together)
+2. **Shared Generation**: One hosts file is generated per device type in `clab_files/shared_hosts/`
+3. **Read-Only Mounting**: Each container gets the shared file mounted as `/etc/hosts:ro`
+
+## Example
+
+For a topology with 10 Linux hosts and 5 FRR routers:
+- **Before**: 15 individual hosts files generated
+- **After**: 2 shared hosts files (one for Linux, one for FRR)
+
+## Implementation Details
+
+The shared hosts file is mounted using Docker's bind mount syntax:
+```
+/path/to/shared/hosts_linux:/etc/hosts:ro
+```
+
+The `:ro` flag ensures the mount is read-only, following security best practices.

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -14,6 +14,7 @@ from ..data import append_to_list, filemaps, get_empty_box
 from ..data.types import must_be_dict
 from ..utils import linuxbridge, log, strings
 from . import _Provider, get_provider_forwarded_ports, node_add_forwarded_ports, validate_mgmt_ip
+from . import shared_hosts
 
 
 def list_bridges( topology: Box ) -> typing.Set[str]:
@@ -181,6 +182,14 @@ class Containerlab(_Provider):
   def post_configuration_create(self, topology: Box) -> None:
     if use_ovs_bridge(topology):
       check_ovs_installation()
+
+    # Generate shared hosts files per device type if enabled
+    hosts_files = shared_hosts.generate_shared_hosts_files(topology, GENERATED_CONFIG_PATH)
+    
+    if hosts_files:
+      # Update node configurations to use shared hosts files
+      shared_hosts.update_node_binds_for_shared_hosts(topology, hosts_files)
+      log.print_verbose(f"Using shared hosts files for {len(hosts_files)} device types")
 
     for n in topology.nodes.values():
       if n.get('clab.binds',None):

--- a/netsim/providers/shared_hosts.py
+++ b/netsim/providers/shared_hosts.py
@@ -88,7 +88,7 @@ def generate_shared_hosts_files(topology: Box, provider_folder: str = "clab_file
             
             template_found = False
             for rel_path in template_paths:
-                full_path = _files.get_moddir() + "/" + rel_path
+                full_path = os.path.join(str(_files.get_moddir()), rel_path)
                 if os.path.exists(full_path):
                     # Write the shared hosts file
                     templates.write_template(

--- a/netsim/providers/shared_hosts.py
+++ b/netsim/providers/shared_hosts.py
@@ -72,8 +72,13 @@ def generate_shared_hosts_files(topology: Box, provider_folder: str = "clab_file
         # Generate hosts file for this device type
         hosts_file_path = f"{shared_hosts_dir}/hosts_{device_type}"
         
-        # Prepare template data
-        template_data = {
+        # Prepare template data - use first node of this device type as base
+        # This ensures we have all the necessary node context
+        first_node_name = next(iter(device_groups[device_type]))
+        base_node = topology.nodes[first_node_name]
+        
+        # Merge with global data like the original implementation
+        template_data = base_node + {
             'hostvars': topology.nodes,
             'hosts': hosts_data,
             'addressing': topology.addressing
@@ -94,7 +99,7 @@ def generate_shared_hosts_files(topology: Box, provider_folder: str = "clab_file
                     templates.write_template(
                         in_folder=os.path.dirname(full_path),
                         j2=os.path.basename(full_path),
-                        data=template_data,
+                        data=template_data.to_dict(),
                         out_folder=shared_hosts_dir,
                         filename=f"hosts_{device_type}"
                     )

--- a/netsim/providers/shared_hosts.py
+++ b/netsim/providers/shared_hosts.py
@@ -1,0 +1,175 @@
+"""
+Shared hosts file generation for containerlab
+
+This module implements industry-standard shared configuration file mounting
+for containerlab containers, avoiding per-node hosts file generation.
+
+Key optimizations:
+1. Generate one hosts file per device type instead of per node
+2. Mount hosts files as read-only to prevent modifications
+3. Use bind mounts following Docker best practices
+4. Eliminate redundant file generation and template processing
+
+Usage:
+    Enable by default or set in topology:
+    defaults.providers.clab.shared_hosts: true
+    
+This approach significantly reduces startup time for large topologies
+by avoiding N hosts file generations for N nodes.
+"""
+
+import os
+import pathlib
+from typing import Dict, Set
+from box import Box
+from ..utils import log, templates, files as _files
+from ..outputs.ansible import get_host_addresses
+
+
+def get_device_groups(topology: Box) -> Dict[str, Set[str]]:
+    """
+    Group nodes by device type to determine which nodes can share hosts files.
+    Returns a dictionary mapping device_type -> set of node names
+    """
+    device_groups: Dict[str, Set[str]] = {}
+    
+    for name, node in topology.nodes.items():
+        device = node.get('device', 'unknown')
+        if device not in device_groups:
+            device_groups[device] = set()
+        device_groups[device].add(name)
+    
+    return device_groups
+
+
+def should_use_shared_hosts(topology: Box) -> bool:
+    """
+    Check if shared hosts files should be used based on configuration.
+    Default is True for optimal performance.
+    """
+    return topology.defaults.providers.clab.get('shared_hosts', True)
+
+
+def generate_shared_hosts_files(topology: Box, provider_folder: str = "clab_files") -> Dict[str, str]:
+    """
+    Generate shared hosts files per device type.
+    Returns a mapping of device_type -> hosts_file_path
+    """
+    if not should_use_shared_hosts(topology):
+        return {}
+    
+    device_groups = get_device_groups(topology)
+    hosts_files: Dict[str, str] = {}
+    
+    # Get the complete hosts data
+    hosts_data = get_host_addresses(topology)
+    
+    # Create shared hosts directory
+    shared_hosts_dir = f"{provider_folder}/shared_hosts"
+    pathlib.Path(shared_hosts_dir).mkdir(parents=True, exist_ok=True)
+    
+    for device_type in device_groups:
+        # Generate hosts file for this device type
+        hosts_file_path = f"{shared_hosts_dir}/hosts_{device_type}"
+        
+        # Prepare template data
+        template_data = {
+            'hostvars': topology.nodes,
+            'hosts': hosts_data,
+            'addressing': topology.addressing
+        }
+        
+        try:
+            # Find the appropriate hosts template
+            template_paths = [
+                f"templates/provider/clab/{device_type}/hosts.j2",
+                "templates/provider/clab/linux/hosts.j2"  # Default fallback
+            ]
+            
+            template_found = False
+            for rel_path in template_paths:
+                full_path = _files.get_moddir() + "/" + rel_path
+                if os.path.exists(full_path):
+                    # Write the shared hosts file
+                    templates.write_template(
+                        in_folder=os.path.dirname(full_path),
+                        j2=os.path.basename(full_path),
+                        data=template_data,
+                        out_folder=shared_hosts_dir,
+                        filename=f"hosts_{device_type}"
+                    )
+                    template_found = True
+                    break
+            
+            if not template_found:
+                log.error(f"Cannot find hosts template for device type {device_type}", log.MissingValue, 'clab')
+                continue
+            
+            hosts_files[device_type] = hosts_file_path
+            log.print_verbose(f"Generated shared hosts file for device type '{device_type}': {hosts_file_path}")
+            
+        except Exception as ex:
+            log.error(
+                f"Error generating shared hosts file for device type {device_type}: {ex}",
+                category=log.IncorrectValue,
+                module='clab'
+            )
+    
+    return hosts_files
+
+
+def update_node_binds_for_shared_hosts(topology: Box, hosts_files: Dict[str, str]) -> None:
+    """
+    Update node configurations to use shared hosts files with read-only bind mounts.
+    Removes individual hosts file generation and replaces with shared mounts.
+    """
+    for name, node in topology.nodes.items():
+        device = node.get('device', 'unknown')
+        
+        if device not in hosts_files:
+            continue
+        
+        # Remove individual hosts template if exists
+        if 'clab.config_templates' in node:
+            templates_dict = {}
+            for item in node.clab.config_templates:
+                if isinstance(item, str) and ':' in item:
+                    src, dst = item.split(':', 1)
+                    if dst != '/etc/hosts':
+                        templates_dict[src] = dst
+                elif isinstance(item, dict):
+                    for src, dst in item.items():
+                        if dst != '/etc/hosts':
+                            templates_dict[src] = dst
+            
+            # Rebuild config_templates without hosts
+            if templates_dict:
+                node.clab.config_templates = [f"{src}:{dst}" for src, dst in templates_dict.items()]
+            else:
+                del node.clab.config_templates
+        
+        # Add shared hosts file as read-only bind mount
+        if 'clab.binds' not in node:
+            node.clab.binds = []
+        
+        # Add the shared hosts file mount with read-only flag
+        shared_hosts_mount = f"{hosts_files[device]}:/etc/hosts:ro"
+        
+        # Check if hosts mount already exists and replace it
+        new_binds = []
+        hosts_mount_added = False
+        
+        for bind in node.clab.binds:
+            if isinstance(bind, str) and ':/etc/hosts' in bind:
+                # Replace existing hosts mount with shared read-only version
+                new_binds.append(shared_hosts_mount)
+                hosts_mount_added = True
+            else:
+                new_binds.append(bind)
+        
+        if not hosts_mount_added:
+            new_binds.append(shared_hosts_mount)
+        
+        node.clab.binds = new_binds
+        
+        log.print_verbose(f"Node '{name}' configured to use shared hosts file for device type '{device}'")


### PR DESCRIPTION
Implement shared hosts file generation and read-only mounting for containerlab to improve performance and follow best practices.

The previous approach generated a unique `/etc/hosts` file for every container, leading to significant overhead in large topologies. This change optimizes the process by generating only one hosts file per device type and sharing it across all containers of that type via read-only bind mounts, reducing file generation from N (nodes) to M (device types) operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-01a468d0-2b89-4264-bdac-fbddca8a691d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01a468d0-2b89-4264-bdac-fbddca8a691d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

