### PR TITLE
Initialize and manage virtualization providers

### DIFF
--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -144,11 +144,12 @@ class _Provider(Callback):
     for file,mapping in map_dict.items():
       file = file.replace('@','.')
       
-      # If hosts template -> create shared per-device file (shared across nodes of same device)
-      if file == 'hosts':
+      # Check if mapping ends with :shared - if so, make it a shared file
+      if mapping.endswith(':shared'):
+        # Remove :shared suffix and replace with :ro
+        mapping = mapping[:-7] + ':ro'  # Remove ':shared' (7 chars) and add ':ro'
         shared_device = node.get('device','shared')
         out_folder = f"{self.provider}_files/shared/{shared_device}"
-        mapping = mapping + ':ro'
       else:
         out_folder = f"{self.provider}_files/{node.name}"
       

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -39,7 +39,6 @@ class _Provider(Callback):
     self.provider = provider
     if 'template' in data:
       self._default_template_name = data.template
-    self._template_cache = {}
 
   @classmethod
   def load(self, provider: str, data: Box) -> '_Provider':
@@ -57,19 +56,6 @@ class _Provider(Callback):
     return str(_files.get_moddir() / self.get_template_path())
 
   def find_extra_template(self, node: Box, fname: str, topology: Box) -> typing.Optional[str]:
-    """Find template with caching to avoid repeated filesystem searches"""
-    # Create a hashable key from mutable objects
-    cache_key = (node.name, node.device, fname, node.get('_daemon', False))
-    
-    if cache_key in self._template_cache:
-      return self._template_cache[cache_key]
-    
-    result = self._find_extra_template_uncached(node, fname, topology)
-    self._template_cache[cache_key] = result
-    return result
-
-  def _find_extra_template_uncached(self, node: Box, fname: str, topology: Box) -> typing.Optional[str]:
-    """Uncached version of find_extra_template"""
     if fname in node.get('config',[]):
       path_prefix = topology.defaults.paths.custom.dirs
       path_suffix = [ fname ]

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -146,8 +146,8 @@ class _Provider(Callback):
       
       # Check if mapping ends with :shared - if so, make it a shared file
       if mapping.endswith(':shared'):
-        # Remove :shared suffix and replace with :ro
-        mapping = mapping[:-7] + ':ro'  # Remove ':shared' (7 chars) and add ':ro'
+        # Replace :shared suffix with :ro
+        mapping = mapping.rsplit(':shared', 1)[0] + ':ro'
         shared_device = node.get('device','shared')
         out_folder = f"{self.provider}_files/shared/{shared_device}"
       else:

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -39,6 +39,7 @@ class _Provider(Callback):
     self.provider = provider
     if 'template' in data:
       self._default_template_name = data.template
+    self._shared_files_cache = {}  # Maps template paths to their shared output paths
 
   @classmethod
   def load(self, provider: str, data: Box) -> '_Provider':
@@ -134,8 +135,7 @@ class _Provider(Callback):
       if mapping.endswith(':shared'):
         # Replace :shared suffix with :ro
         mapping = mapping.rsplit(':shared', 1)[0] + ':ro'
-        shared_device = node.get('device','shared')
-        out_folder = f"{self.provider}_files/shared/{shared_device}"
+        out_folder = f"{self.provider}_files/shared"
       else:
         out_folder = f"{self.provider}_files/{node.name}"
       
@@ -183,37 +183,40 @@ class _Provider(Callback):
       if not file.startswith(prefix):
         continue
 
-      # Derive the out_folder (either node-specific or shared per-device) and the relative filename
-      rel = file[prefix_len:]  # e.g. 'node1/etc/hosts' or 'shared/<device>/etc/hosts'
+      # Derive the out_folder and the relative filename
+      rel = file[prefix_len:]  # e.g. 'node1/etc/hosts' or 'shared/etc/hosts'
       if rel.startswith('shared/'):
-        # expected rel: 'shared/<device>/path/to/file'
-        parts = rel.split('/',2)
-        if len(parts) < 3:
-          file_rel = parts[-1]
-        else:
-          file_rel = parts[2]
-        out_folder = f"{prefix}{parts[0]}/{parts[1]}"   # provider_files/shared/<device>
+        # Shared file path
+        file_rel = rel[7:]  # Remove 'shared/' prefix
+        is_shared = True
       else:
         parts = rel.split('/',1)
-        out_folder = f"{prefix}{parts[0]}"               # provider_files/<node.name>
         file_rel = parts[1] if len(parts) > 1 else ''
+        is_shared = False
 
       if not file_rel:
         # nothing to render
         continue
 
-      full_out_path = pathlib.Path(out_folder) / file_rel
-
       template_name = self.find_extra_template(node, file_rel, topology)
-
       if not template_name:
         log.error(f"Cannot find template for {file_rel} on node {node.name}",log.MissingValue,'provider')
         continue
 
+      # Check if this is a shared template that's already been rendered
+      if is_shared and template_name in self._shared_files_cache:
+        full_out_path = self._shared_files_cache[template_name]
+      else:
+        # Determine output path
+        if is_shared:
+          full_out_path = pathlib.Path(f"{prefix}shared") / file_rel
+        else:
+          full_out_path = pathlib.Path(file)
+
       # Create parent dirs if needed
       full_out_path.parent.mkdir(parents=True,exist_ok=True)
 
-      # If the shared file already exists, skip re-rendering (shared per-device)
+      # If the file already exists (either shared or node-specific), skip re-rendering
       if full_out_path.exists():
         if not log.QUIET:
           strings.print_colored_text('[MAPPED]  ','bright_cyan','Mapped ')
@@ -231,6 +234,10 @@ class _Provider(Callback):
         log.fatal(
           text=f"Error rendering {template_name} into {file_rel}\n{strings.extra_data_printout(str(ex))}",
           module=self.provider)
+
+      # Cache shared templates for reuse
+      if is_shared:
+        self._shared_files_cache[template_name] = full_out_path
 
       if not log.QUIET:
         strings.print_colored_text('[MAPPED]  ','bright_cyan','Mapped ')


### PR DESCRIPTION
Implement a generic file sharing mechanism by converting `:shared` target names to `:ro` and placing them in a shared directory.

Previously, only the 'hosts' file was hardcoded to be shared across nodes of the same device type. This update generalizes the functionality, enabling any configuration file to be shared by simply appending `:shared` to its target mapping. This provides greater flexibility and reduces hardcoded logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea37a475-dcf0-4c52-b6b2-aa3dc5197dc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea37a475-dcf0-4c52-b6b2-aa3dc5197dc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

